### PR TITLE
Switch babel plugins to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "A utility method to create preact components without using class keyword",
   "main": "./dist/index.js",
   "dependencies": {
-    "babel-plugin-transform-object-assign": "^6.5.0",
-    "babel-preset-es2015": "^6.6.0",
     "preact": "^6.4.0"
   },
   "devDependencies": {
     "babel-cli": "^6.7.7",
     "babel-register": "^6.7.2",
+    "babel-plugin-transform-object-assign": "^6.5.0",
+    "babel-preset-es2015": "^6.6.0",
     "chai": "^3.5.0",
     "jscs": "^3.0.3",
     "mocha": "^3.1.2",


### PR DESCRIPTION
We don't need babel to use the module, only to develop on it.

I think we can move babel-related stuff to devDependencies.